### PR TITLE
fix: use sha commits for gh actions instead of tags

### DIFF
--- a/.github/workflows/ci-check.yaml
+++ b/.github/workflows/ci-check.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: 'latest'
 
@@ -46,6 +46,6 @@ jobs:
       - general-checks
     steps:
       - name: Decide on PR checks
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.ref || '' }}
 
@@ -52,7 +52,7 @@ jobs:
           echo "value=${GITHUB_REF_NAME#*-}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
 
       - name: Deploy mdBook to gh-pages
         uses: matter-labs/deploy-mdbooks@c72ae3825faeb7d20cbf3e67714f7253dd0ee7cb

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || '' }}
@@ -45,21 +45,38 @@ jobs:
       - name: Determine tag
         id: tag
         run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          TAG_INPUT="${{ inputs.tag }}"
+          
+          # Check if the tag input is provided
+          if [ -n "$TAG_INPUT" ]; then
+            # Sanitize the input - request by security team
+            # Replace any character that is NOT 
+            # alphanumeric, a hyphen, an underscore, or a period with nothing.
+            # This prevents unexpected shell chars (like ;, $, |, etc.) 
+            # from being executed.
+            SANITIZED_TAG=$(echo "$TAG_INPUT" | tr -cd '[:alnum:]._-')
+            
+            # Use the sanitized tag
+            echo "value=$SANITIZED_TAG" >> "$GITHUB_OUTPUT"
+            
+            if [ "$TAG_INPUT" != "$SANITIZED_TAG" ]; then
+              echo "Warning: Input tag was sanitized from '$TAG_INPUT' to '$SANITIZED_TAG'"
+            fi
+            
           else
+            # Fallback to commit short SHA if no tag is provided
             echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update release-please release artifacts
         if: ${{ inputs.tag != '' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2
         with:
           tag_name: ${{ inputs.tag }}
 
       - name: Publish release
         if: ${{ inputs.prerelease_name != '' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2
         with:
           tag_name: ${{ steps.tag.outputs.value }}
           name: zksync-js ${{ steps.tag.outputs.value }}${{ inputs.prerelease_name && format(' {0}', inputs.prerelease_name) || '' }}
@@ -75,14 +92,14 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
             bun-version: 'latest'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -14,10 +14,10 @@ jobs:
     name: unit-tests 🧪
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: 'latest'
 
@@ -34,7 +34,7 @@ jobs:
           mv coverage/lcov.info lcov.unit.info
 
       - name: Upload unit coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: lcov-unit
           path: lcov.unit.info
@@ -45,10 +45,10 @@ jobs:
     needs: unit-tests
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: 'latest'
 
@@ -59,12 +59,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
 
       - name: Install Foundry (anvil)
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5
         with:
           version: v1.3.4
 
       - name: Run ZKsync OS (L1-L2)
-        uses: dutterbutter/zksync-server-action@v0.1.0
+        uses: dutterbutter/zksync-server-action@6cb6ddb5b674810fead2d2ba2ee95e640800c434 # v1
 
       - name: Compile test contracts
         working-directory: tests/contracts
@@ -88,7 +88,7 @@ jobs:
           lcov -a lcov.e2e.ethers.info -a lcov.e2e.viem.info -o lcov.e2e.info
 
       - name: Upload e2e coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: lcov-e2e
           path: lcov.e2e.info
@@ -101,15 +101,15 @@ jobs:
       pull-requests: write
     needs: [unit-tests, e2e-tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: lcov-unit
           path: ./cov
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: lcov-e2e
           path: ./cov
@@ -121,7 +121,7 @@ jobs:
 
       - name: Report coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: zgosalvez/github-actions-report-lcov@v4
+        uses: zgosalvez/github-actions-report-lcov@b9c423417947b8f4156df37174e5a8be99a02747 # v5
         with:
           coverage-files: ./cov/lcov.merged.info
           minimum-coverage: 80
@@ -131,7 +131,7 @@ jobs:
           title-prefix: "ci-run-tests"
 
       - name: Upload merged LCOV
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: lcov-merged
           path: ./cov/lcov.merged.info
@@ -144,18 +144,18 @@ jobs:
     needs: coverage-merge
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
 
       - name: Download merged LCOV
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: lcov-merged
           path: ./cov
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           files: ./cov/lcov.merged.info
           flags: combined

--- a/.github/workflows/secrets_scanner.yaml
+++ b/.github/workflows/secrets_scanner.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: TruffleHog OSS


### PR DESCRIPTION
# What :computer:

- use sha commits for gh actions instead of tags
- Sanitizes git tag for releases

# Why :hand:

- Security request

# Evidence :camera:

Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
