### PR TITLE
fix: improve viem approve planning for no-return ERC20s

### DIFF
--- a/src/adapters/__tests__/deposits/erc20-base.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-base.test.ts
@@ -20,6 +20,11 @@ const ROUTES = {
   viem: routeViem(),
 } as const;
 
+const noReturnApproveError = () =>
+  Object.assign(new Error('The contract function "approve" returned no data ("0x").'), {
+    name: 'ContractFunctionExecutionError',
+  });
+
 describeForAdapters('adapters/deposits/routeErc20Base', (kind, factory) => {
   it('skips approval when allowance covers mintValue and builds a zero-value bridge tx', async () => {
     const harness = factory();
@@ -101,6 +106,70 @@ describeForAdapters('adapters/deposits/routeErc20Base', (kind, factory) => {
     expect(info.mintValue).toBe(expectedMint);
     expect(info.l2Value).toBe(amount);
   });
+
+  if (kind === 'viem') {
+    it('builds an approval request when approve simulation returns no data', async () => {
+      const harness = factory();
+      const ctx = makeDepositContext(harness);
+      const amount = 5_000n;
+      const baseCost = 4_000n;
+      const expectedMint = baseCost + ctx.operatorTip + amount;
+
+      setBridgehubBaseCost(harness, ctx, baseCost);
+      setErc20Allowance(
+        harness,
+        ADAPTER_TEST_ADDRESSES.baseTokenFor324,
+        ctx.sender,
+        ctx.l1AssetRouter,
+        expectedMint - 1n,
+      );
+      harness.setSimulateError(noReturnApproveError());
+
+      const res = await ROUTES.viem.build(
+        { token: ADAPTER_TEST_ADDRESSES.baseTokenFor324, amount } as any,
+        ctx as any,
+      );
+
+      expect(res.approvals.length).toBe(1);
+      expect(res.steps.length).toBe(2);
+
+      const approveInfo = parseApproveTx('viem', res.steps[0].tx);
+      expect(approveInfo.to).toBe(ADAPTER_TEST_ADDRESSES.baseTokenFor324.toLowerCase());
+      expect(approveInfo.spender).toBe(ctx.l1AssetRouter.toLowerCase());
+      expect(approveInfo.amount).toBe(expectedMint);
+    });
+
+    it('still wraps non no-return approve simulation failures', async () => {
+      const harness = factory();
+      const ctx = makeDepositContext(harness);
+      const amount = 5_000n;
+      const baseCost = 4_000n;
+      const expectedMint = baseCost + ctx.operatorTip + amount;
+
+      setBridgehubBaseCost(harness, ctx, baseCost);
+      setErc20Allowance(
+        harness,
+        ADAPTER_TEST_ADDRESSES.baseTokenFor324,
+        ctx.sender,
+        ctx.l1AssetRouter,
+        expectedMint - 1n,
+      );
+      harness.setSimulateError(new Error('execution reverted'));
+
+      let caught: unknown;
+      try {
+        await ROUTES.viem.build(
+          { token: ADAPTER_TEST_ADDRESSES.baseTokenFor324, amount } as any,
+          ctx as any,
+        );
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(isZKsyncError(caught)).toBe(true);
+      expect(String(caught)).toMatch(/Failed to simulate ERC-20 approve/);
+    });
+  }
 
   if (kind === 'ethers') {
     it('ignores estimateGas failures and falls back to the safe gas limit', async () => {

--- a/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
@@ -11,7 +11,11 @@ import {
 } from '../adapter-harness.ts';
 import { FORMAL_ETH_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../core/constants.ts';
 import { isZKsyncError } from '../../../core/types/errors.ts';
-import { decodeSecondBridgeErc20, decodeTwoBridgeOuter } from '../decode-helpers.ts';
+import {
+  decodeSecondBridgeErc20,
+  decodeTwoBridgeOuter,
+  parseApproveTx,
+} from '../decode-helpers.ts';
 
 type AdapterKind = 'ethers' | 'viem';
 
@@ -25,6 +29,10 @@ const MIN_L2_GAS_FOR_ERC20 = 2_500_000n;
 const ERC20_TOKEN = '0x3333333333333333333333333333333333333333' as const;
 const BASE_TOKEN = ADAPTER_TEST_ADDRESSES.baseTokenFor324;
 const RECEIVER = '0x4444444444444444444444444444444444444444' as const;
+const noReturnApproveError = () =>
+  Object.assign(new Error('The contract function "approve" returned no data ("0x").'), {
+    name: 'ContractFunctionExecutionError',
+  });
 
 describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
   it('handles non-base ERC-20 where fees are paid in ETH (no approvals required)', async () => {
@@ -142,6 +150,40 @@ describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
       expect(BigInt((bridgeTx.args?.[0] as any)?.mintValue ?? 0n)).toBe(mintValue);
     }
   });
+
+  if (kind === 'viem') {
+    it('builds both approval requests when approve simulations return no data', async () => {
+      const harness = factory();
+      const ctx = makeDepositContext(harness, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });
+      const amount = 5_000n;
+      const baseCost = 4_000n;
+      const mintValue = baseCost + ctx.operatorTip;
+
+      setBridgehubBaseToken(harness, ctx, BASE_TOKEN);
+      setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });
+      setErc20Allowance(harness, ERC20_TOKEN, ctx.sender, ctx.l1AssetRouter, amount - 1n);
+      setErc20Allowance(harness, BASE_TOKEN, ctx.sender, ctx.l1AssetRouter, mintValue - 1n);
+      harness.setSimulateError(noReturnApproveError());
+
+      const res = await ROUTES.viem.build(
+        { token: ERC20_TOKEN, amount, to: RECEIVER } as any,
+        ctx as any,
+      );
+
+      expect(res.approvals.length).toBe(2);
+      expect(res.steps.length).toBe(3);
+
+      const depositApprove = parseApproveTx('viem', res.steps[0].tx);
+      expect(depositApprove.to).toBe(ERC20_TOKEN.toLowerCase());
+      expect(depositApprove.spender).toBe(ctx.l1AssetRouter.toLowerCase());
+      expect(depositApprove.amount).toBe(amount);
+
+      const baseApprove = parseApproveTx('viem', res.steps[1].tx);
+      expect(baseApprove.to).toBe(BASE_TOKEN.toLowerCase());
+      expect(baseApprove.spender).toBe(ctx.l1AssetRouter.toLowerCase());
+      expect(baseApprove.amount).toBe(mintValue);
+    });
+  }
 
   if (kind === 'ethers') {
     it('ignores estimateGas failures and applies the safe fallback gas limit', async () => {

--- a/src/adapters/__tests__/deposits/eth-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/eth-nonbase.test.ts
@@ -52,6 +52,10 @@ const WETH_L2 = '0x6666666666666666666666666666666666666666' as Address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 const ETH_METADATA = '0x123456' as Hex;
 const DEPLOYED_ETH_L2_CALLDATA = '0x12345678' as Hex;
+const noReturnApproveError = () =>
+  Object.assign(new Error('The contract function "approve" returned no data ("0x").'), {
+    name: 'ContractFunctionExecutionError',
+  });
 
 function makeResolvedEthToken(l2Token: Address = ETH_ADDRESS): ResolvedToken {
   return {
@@ -193,6 +197,38 @@ describeForAdapters('adapters/deposits/routeEthNonBase', (kind, factory) => {
       expect(BigInt(req.secondBridgeValue ?? 0n)).toBe(amount);
     }
   });
+
+  if (kind === 'viem') {
+    it('builds the base-token approval request when approve simulation returns no data', async () => {
+      const harness = factory();
+      const ctx = makeDepositContext(harness, {
+        l2GasLimit: MIN_L2_GAS_FOR_ETH_NONBASE,
+        baseTokenL1: BASE_TOKEN,
+        baseIsEth: false,
+        resolvedToken: makeResolvedEthToken(),
+      });
+      const amount = 5_000n;
+      const baseCost = 4_000n;
+      const mintValue = baseCost + ctx.operatorTip;
+
+      setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: MIN_L2_GAS_FOR_ETH_NONBASE });
+      setErc20Allowance(harness, BASE_TOKEN, ctx.sender, ctx.l1AssetRouter, mintValue - 1n);
+      harness.setSimulateError(noReturnApproveError());
+
+      const res = await ROUTES.viem.build(
+        { token: FORMAL_ETH_ADDRESS, amount, to: RECEIVER } as any,
+        ctx as any,
+      );
+
+      expect(res.approvals.length).toBe(1);
+      expect(res.steps.length).toBe(2);
+
+      const approveInfo = parseApproveTx('viem', res.steps[0].tx);
+      expect(approveInfo.to).toBe(BASE_TOKEN.toLowerCase());
+      expect(approveInfo.spender).toBe(ctx.l1AssetRouter.toLowerCase());
+      expect(approveInfo.amount).toBe(mintValue);
+    });
+  }
 
   it('uses the derived priority-floor gas limit when the bridged ETH token is already deployed on L2', async () => {
     const harness = factory();

--- a/src/adapters/viem/resources/deposits/routes/approval.ts
+++ b/src/adapters/viem/resources/deposits/routes/approval.ts
@@ -1,0 +1,71 @@
+import type { Abi } from 'viem';
+
+import { IERC20ABI } from '../../../../../core/abi.ts';
+import type { Address } from '../../../../../core/types/primitives';
+import type { BuildCtx } from '../context';
+import type { ViemPlanWriteRequest } from './types';
+
+type BuildApprovalRequestInput = {
+  ctx: BuildCtx;
+  token: Address;
+  spender: Address;
+  amount: bigint;
+};
+
+function errorText(error: unknown): string {
+  const parts: string[] = [];
+  let current = error as { cause?: unknown } | undefined;
+
+  for (let depth = 0; current && depth < 8; depth++) {
+    const record = current as Record<string, unknown>;
+    for (const key of ['name', 'shortMessage', 'message', 'details']) {
+      const value = record[key];
+      if (typeof value === 'string') parts.push(value);
+    }
+    current = record.cause as { cause?: unknown } | undefined;
+  }
+
+  return parts.join('\n');
+}
+
+function isNoReturnApproveSimulationError(error: unknown): boolean {
+  const text = errorText(error);
+
+  return (
+    /approve/i.test(text) &&
+    (/returned no data/i.test(text) ||
+      /return(?:ed)? data[^\n]*0x/i.test(text) ||
+      /0x[^\n]*no data/i.test(text))
+  );
+}
+
+export async function buildApprovalRequest({
+  ctx,
+  token,
+  spender,
+  amount,
+}: BuildApprovalRequestInput): Promise<ViemPlanWriteRequest> {
+  try {
+    const sim = await ctx.client.l1.simulateContract({
+      address: token,
+      abi: IERC20ABI as Abi,
+      functionName: 'approve',
+      args: [spender, amount] as const,
+      account: ctx.client.account,
+    });
+
+    return { ...sim.request } as ViemPlanWriteRequest;
+  } catch (error) {
+    if (!isNoReturnApproveSimulationError(error)) {
+      throw error;
+    }
+
+    return {
+      address: token,
+      abi: IERC20ABI as Abi,
+      functionName: 'approve',
+      args: [spender, amount] as const,
+      account: ctx.client.account,
+    } as ViemPlanWriteRequest;
+  }
+}

--- a/src/adapters/viem/resources/deposits/routes/erc20-base.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-base.ts
@@ -18,6 +18,7 @@ import { quoteL2BaseCost } from '../services/fee.ts';
 import { buildFeeBreakdown } from '../../../../../core/resources/deposits/fee.ts';
 import { applyPriorityL2GasLimitBuffer } from '../../../../../core/resources/deposits/priority.ts';
 import { getPriorityTxGasBreakdown } from './priority';
+import { buildApprovalRequest } from './approval';
 
 const { wrapAs } = createErrorHandlers('deposits');
 const EMPTY_BYTES = '0x' as const;
@@ -105,16 +106,15 @@ export function routeErc20Base(): DepositRouteStrategy {
       const needsApprove = allowance < mintValue;
 
       if (needsApprove) {
-        const approveSim = await wrapAs(
+        const approveTx = await wrapAs(
           'CONTRACT',
           OP_DEPOSITS.base.estGas,
           () =>
-            ctx.client.l1.simulateContract({
-              address: baseToken,
-              abi: IERC20ABI as Abi,
-              functionName: 'approve',
-              args: [ctx.l1AssetRouter, mintValue] as const,
-              account: ctx.client.account,
+            buildApprovalRequest({
+              ctx,
+              token: baseToken,
+              spender: ctx.l1AssetRouter,
+              amount: mintValue,
             }),
           {
             ctx: { where: 'l1.simulateContract', to: baseToken },
@@ -127,7 +127,7 @@ export function routeErc20Base(): DepositRouteStrategy {
           key: `approve:${baseToken}:${ctx.l1AssetRouter}`,
           kind: 'approve',
           description: 'Approve base token for mintValue',
-          tx: { ...approveSim.request },
+          tx: approveTx,
         });
       }
 

--- a/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
@@ -21,6 +21,7 @@ import {
   derivePriorityBodyGasEstimateCap,
 } from '../../../../../core/resources/deposits/priority.ts';
 import { getPriorityTxGasBreakdown } from './priority';
+import { buildApprovalRequest } from './approval';
 
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
@@ -204,16 +205,15 @@ export function routeErc20NonBase(): DepositRouteStrategy {
       )) as bigint;
 
       if (depositAllowance < p.amount) {
-        const approveSim = await wrapAs(
+        const approveTx = await wrapAs(
           'CONTRACT',
           OP_DEPOSITS.nonbase.estGas,
           () =>
-            ctx.client.l1.simulateContract({
-              address: p.token,
-              abi: IERC20ABI as Abi,
-              functionName: 'approve',
-              args: [assetRouter, p.amount] as const,
-              account: ctx.client.account,
+            buildApprovalRequest({
+              ctx,
+              token: p.token,
+              spender: assetRouter,
+              amount: p.amount,
             }),
           {
             ctx: { where: 'l1.simulateContract', to: p.token },
@@ -226,7 +226,7 @@ export function routeErc20NonBase(): DepositRouteStrategy {
           key: `approve:${p.token}:${assetRouter}`,
           kind: 'approve',
           description: `Approve deposit token for amount`,
-          tx: { ...approveSim.request },
+          tx: approveTx,
         });
       }
 
@@ -248,16 +248,15 @@ export function routeErc20NonBase(): DepositRouteStrategy {
         )) as bigint;
 
         if (baseAllowance < mintValue) {
-          const approveBaseSim = await wrapAs(
+          const approveBaseTx = await wrapAs(
             'CONTRACT',
             OP_DEPOSITS.nonbase.estGas,
             () =>
-              ctx.client.l1.simulateContract({
-                address: baseToken,
-                abi: IERC20ABI as Abi,
-                functionName: 'approve',
-                args: [assetRouter, mintValue] as const,
-                account: ctx.client.account,
+              buildApprovalRequest({
+                ctx,
+                token: baseToken,
+                spender: assetRouter,
+                amount: mintValue,
               }),
             {
               ctx: { where: 'l1.simulateContract', to: baseToken },
@@ -270,7 +269,7 @@ export function routeErc20NonBase(): DepositRouteStrategy {
             key: `approve:${baseToken}:${assetRouter}`,
             kind: 'approve',
             description: `Approve base token for mintValue`,
-            tx: { ...approveBaseSim.request },
+            tx: approveBaseTx,
           });
         }
       }

--- a/src/adapters/viem/resources/deposits/routes/eth-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/eth-nonbase.ts
@@ -33,6 +33,7 @@ import {
   derivePriorityBodyGasEstimateCap,
 } from '../../../../../core/resources/deposits/priority.ts';
 import { getPriorityTxGasBreakdown } from './priority';
+import { buildApprovalRequest } from './approval';
 
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
@@ -215,16 +216,15 @@ export function routeEthNonBase(): DepositRouteStrategy {
       const needsApprove = allowance < mintValue;
 
       if (needsApprove) {
-        const approveSim = await wrapAs(
+        const approveTx = await wrapAs(
           'CONTRACT',
           OP_DEPOSITS.ethNonBase.estGas,
           () =>
-            ctx.client.l1.simulateContract({
-              address: baseToken,
-              abi: IERC20ABI,
-              functionName: 'approve',
-              args: [ctx.l1AssetRouter, mintValue] as const,
-              account: ctx.client.account,
+            buildApprovalRequest({
+              ctx,
+              token: baseToken,
+              spender: ctx.l1AssetRouter,
+              amount: mintValue,
             }),
           {
             ctx: { where: 'l1.simulateContract', to: baseToken },
@@ -237,7 +237,7 @@ export function routeEthNonBase(): DepositRouteStrategy {
           key: `approve:${baseToken}:${ctx.l1AssetRouter}`,
           kind: 'approve',
           description: `Approve base token for fees (mintValue)`,
-          tx: { ...approveSim.request },
+          tx: approveTx,
         });
       }
 


### PR DESCRIPTION
## Summary

Fixes viem deposit approval planning for ERC-20 tokens whose `approve(address,uint256)` succeeds but returns no data, such as USDT-style tokens.

The viem routes still use `simulateContract()` for standard ERC-20 approvals. If that simulation fails specifically with a no-return-data approval decode error, the SDK now falls back to building the same `writeContract`-ready approval request directly. Other approval simulation failures still bubble through the existing deposit error wrapper.

Affected routes:
- `erc20-base`
- `erc20-nonbase`
- `eth-nonbase`

Fixes #96.

## Validation

- `bun test src/adapters/__tests__/deposits/erc20-base.test.ts src/adapters/__tests__/deposits/erc20-nonbase.test.ts src/adapters/__tests__/deposits/eth-nonbase.test.ts`
- `bun test src/adapters/__tests__ src/core`
- `bun run typecheck`
- `bun run build:types`
- `bun run build`
- `bun run format:check`
- `bunx prettier --check src/adapters/viem/resources/deposits/routes/approval.ts src/adapters/viem/resources/deposits/routes/erc20-base.ts src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts src/adapters/viem/resources/deposits/routes/eth-nonbase.ts src/adapters/__tests__/deposits/erc20-base.test.ts src/adapters/__tests__/deposits/erc20-nonbase.test.ts src/adapters/__tests__/deposits/eth-nonbase.test.ts`
- `bunx eslint --no-warn-ignored src/adapters/viem/resources/deposits/routes/approval.ts src/adapters/viem/resources/deposits/routes/erc20-base.ts src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts src/adapters/viem/resources/deposits/routes/eth-nonbase.ts src/adapters/__tests__/deposits/erc20-base.test.ts src/adapters/__tests__/deposits/erc20-nonbase.test.ts src/adapters/__tests__/deposits/eth-nonbase.test.ts`
- `git diff --check`

Notes:
- `bun run lint` exits successfully with four pre-existing `no-console` warnings in unrelated files.
- Full `bun run test` still fails on docs snippets that require env credentials or contain placeholder private keys (`PRIVATE_KEY`, `L1_RPC_URL`, `L2_RPC_URL`), while the non-doc unit surface passes.
