### PR TITLE
fix: user proper calldata encoding for non-L1 ERC20 deposit

### DIFF
--- a/src/adapters/__tests__/adapter-harness.ts
+++ b/src/adapters/__tests__/adapter-harness.ts
@@ -176,6 +176,9 @@ function makeEthersL1(state: EthersL1State) {
     async getGasPrice() {
       return 5n;
     },
+    async getNetwork() {
+      return { chainId: 324n };
+    },
   };
 }
 

--- a/src/adapters/__tests__/decode-helpers.ts
+++ b/src/adapters/__tests__/decode-helpers.ts
@@ -34,6 +34,25 @@ export function decodeSecondBridgeErc20(calldata: string) {
   };
 }
 
+export function decodeSecondBridgeDataV1(calldata: string) {
+  if (!calldata.toLowerCase().startsWith('0x01')) {
+    throw new Error('second bridge calldata is not V1 encoded');
+  }
+
+  const [assetId, transferData] = coder.decode(['bytes32', 'bytes'], `0x${calldata.slice(4)}`);
+  const [amount, receiver, token] = coder.decode(
+    ['uint256', 'address', 'address'],
+    transferData as string,
+  );
+
+  return {
+    assetId: assetId as `0x${string}`,
+    amount: BigInt(amount),
+    receiver: (receiver as string).toLowerCase(),
+    token: (token as string).toLowerCase(),
+  };
+}
+
 export function decodeAssetRouterWithdraw(data: string) {
   const [assetId, assetData] = L2AssetRouter.decodeFunctionData('withdraw(bytes32,bytes)', data);
   const [amount, receiver, token] = coder.decode(['uint256', 'address', 'address'], assetData);

--- a/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
@@ -13,6 +13,7 @@ import { FORMAL_ETH_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../core/constants.
 import { isZKsyncError } from '../../../core/types/errors.ts';
 import type { ResolvedToken } from '../../../core/types/flows/token.ts';
 import type { Address, Hex } from '../../../core/types/primitives.ts';
+import {
   decodeSecondBridgeDataV1,
   decodeSecondBridgeErc20,
   decodeTwoBridgeOuter,

--- a/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
@@ -11,7 +11,13 @@ import {
 } from '../adapter-harness.ts';
 import { FORMAL_ETH_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../core/constants.ts';
 import { isZKsyncError } from '../../../core/types/errors.ts';
-import { decodeSecondBridgeErc20, decodeTwoBridgeOuter } from '../decode-helpers.ts';
+import {
+  decodeSecondBridgeDataV1,
+  decodeSecondBridgeErc20,
+  decodeTwoBridgeOuter,
+} from '../decode-helpers.ts';
+import type { ResolvedToken } from '../../../core/types/flows/token.ts';
+import type { Address, Hex } from '../../../core/types/primitives.ts';
 
 type AdapterKind = 'ethers' | 'viem';
 
@@ -23,8 +29,26 @@ const ROUTES = {
 const MIN_L2_GAS_FOR_ERC20 = 2_500_000n;
 
 const ERC20_TOKEN = '0x3333333333333333333333333333333333333333' as const;
+const ERC20_TOKEN_L2 = '0x5555555555555555555555555555555555555555' as Address;
 const BASE_TOKEN = ADAPTER_TEST_ADDRESSES.baseTokenFor324;
 const RECEIVER = '0x4444444444444444444444444444444444444444' as const;
+const BASE_TOKEN_ASSET_ID = `0x${'11'.repeat(32)}` as Hex;
+const NON_L1_ORIGIN_ASSET_ID = `0x${'22'.repeat(32)}` as Hex;
+
+function makeResolvedErc20Token(overrides: Partial<ResolvedToken> = {}): ResolvedToken {
+  return {
+    kind: 'erc20',
+    l1: ERC20_TOKEN,
+    l2: ERC20_TOKEN_L2,
+    assetId: NON_L1_ORIGIN_ASSET_ID,
+    originChainId: 9n,
+    isChainEthBased: true,
+    baseTokenAssetId: BASE_TOKEN_ASSET_ID,
+    wethL1: FORMAL_ETH_ADDRESS,
+    wethL2: FORMAL_ETH_ADDRESS,
+    ...overrides,
+  };
+}
 
 describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
   it('handles non-base ERC-20 where fees are paid in ETH (no approvals required)', async () => {
@@ -77,6 +101,44 @@ describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
       expect(BigInt(infoArgs.mintValue ?? 0n)).toBe(mintValue);
       expect(BigInt(infoArgs.l2GasLimit ?? 0n)).toBe(MIN_L2_GAS_FOR_ERC20);
     }
+  });
+
+  it('uses V1 second-bridge calldata for ERC-20 tokens that do not originate on L1', async () => {
+    const harness = factory();
+    const ctx = makeDepositContext(harness, {
+      l2GasLimit: MIN_L2_GAS_FOR_ERC20,
+      baseTokenL1: FORMAL_ETH_ADDRESS,
+      baseIsEth: true,
+      resolvedToken: makeResolvedErc20Token(),
+    });
+    const amount = 1_000n;
+    const baseCost = 3_000n;
+    const mintValue = baseCost + ctx.operatorTip;
+
+    setBridgehubBaseToken(harness, ctx, FORMAL_ETH_ADDRESS);
+    setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });
+    setErc20Allowance(harness, ERC20_TOKEN, ctx.sender, ctx.l1AssetRouter, amount);
+
+    const res = await ROUTES[kind].build(
+      { token: ERC20_TOKEN, amount, to: RECEIVER } as any,
+      ctx as any,
+    );
+
+    expect(res.approvals.length).toBe(0);
+    expect(res.steps.length).toBe(1);
+    expect(res.fees?.mintValue).toBe(mintValue);
+
+    const bridge = res.steps[0];
+    const secondBridgeCalldata =
+      kind === 'ethers'
+        ? decodeTwoBridgeOuter((bridge.tx as any).data).secondBridgeCalldata
+        : ((bridge.tx as any).args?.[0] as any).secondBridgeCalldata;
+    const decoded = decodeSecondBridgeDataV1(secondBridgeCalldata);
+
+    expect(decoded.assetId.toLowerCase()).toBe(NON_L1_ORIGIN_ASSET_ID.toLowerCase());
+    expect(decoded.amount).toBe(amount);
+    expect(decoded.receiver).toBe(RECEIVER.toLowerCase());
+    expect(decoded.token).toBe(ERC20_TOKEN.toLowerCase());
   });
 
   it('requires approvals when deposit and base allowances are insufficient', async () => {

--- a/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
@@ -3,7 +3,11 @@
 import type { DepositRouteStrategy } from './types';
 import { AbiCoder, Contract, Interface } from 'ethers';
 import type { TransactionRequest } from 'ethers';
-import { encodeSecondBridgeErc20Args } from '../../utils';
+import {
+  encodeNativeTokenVaultTransferData,
+  encodeSecondBridgeDataV1,
+  encodeSecondBridgeErc20Args,
+} from '../../utils';
 import { IERC20ABI, IL2AssetRouterABI } from '../../../../../core/abi.ts';
 import type { ApprovalNeed, PlanStep } from '../../../../../core/types/flows/base';
 import { createErrorHandlers } from '../../../errors/error-ops';
@@ -29,6 +33,35 @@ type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
   undeployedGasLimit?: bigint;
 };
+
+async function encodeSecondBridgeErc20DepositCalldata(input: {
+  ctx: Parameters<DepositRouteStrategy['build']>[1];
+  token: `0x${string}`;
+  amount: bigint;
+  receiver: `0x${string}`;
+}): Promise<`0x${string}`> {
+  if (!input.ctx.resolvedToken) {
+    return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
+  }
+
+  const { chainId: l1ChainId } = await input.ctx.client.l1.getNetwork();
+  const isL1Origin =
+    input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
+    input.ctx.resolvedToken.originChainId === 0n ||
+    input.ctx.resolvedToken.originChainId === BigInt(l1ChainId);
+
+  if (isL1Origin) {
+    return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
+  }
+
+  const transferData = encodeNativeTokenVaultTransferData(
+    input.amount,
+    input.receiver,
+    input.token,
+  );
+
+  return encodeSecondBridgeDataV1(input.ctx.resolvedToken.assetId, transferData) as `0x${string}`;
+}
 
 async function getPriorityGasModel(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
@@ -127,9 +160,15 @@ export function routeErc20NonBase(): DepositRouteStrategy {
       const secondBridgeCalldata = await wrapAs(
         'INTERNAL',
         OP_DEPOSITS.nonbase.encodeCalldata,
-        () => Promise.resolve(encodeSecondBridgeErc20Args(p.token, p.amount, receiver)),
+        () =>
+          encodeSecondBridgeErc20DepositCalldata({
+            ctx,
+            token: p.token,
+            amount: p.amount,
+            receiver,
+          }),
         {
-          ctx: { where: 'encodeSecondBridgeErc20Args' },
+          ctx: { where: 'encodeSecondBridgeErc20DepositCalldata' },
           message: 'Failed to encode bridging calldata.',
         },
       );

--- a/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
@@ -7,7 +7,11 @@ import type { DepositRouteStrategy, ViemPlanWriteRequest } from './types';
 import type { PlanStep, ApprovalNeed } from '../../../../../core/types/flows/base';
 
 import { IERC20ABI, IBridgehubABI, IL2AssetRouterABI } from '../../../../../core/abi.ts';
-import { encodeSecondBridgeErc20Args } from '../../utils';
+import {
+  encodeNativeTokenVaultTransferData,
+  encodeSecondBridgeDataV1,
+  encodeSecondBridgeErc20Args,
+} from '../../utils';
 import { createErrorHandlers } from '../../../errors/error-ops';
 import { OP_DEPOSITS } from '../../../../../core/types';
 import { isETH, normalizeAddrEq } from '../../../../../core/utils/addr';
@@ -29,6 +33,35 @@ type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
   undeployedGasLimit?: bigint;
 };
+
+async function encodeSecondBridgeErc20DepositCalldata(input: {
+  ctx: Parameters<DepositRouteStrategy['build']>[1];
+  token: `0x${string}`;
+  amount: bigint;
+  receiver: `0x${string}`;
+}): Promise<`0x${string}`> {
+  if (!input.ctx.resolvedToken) {
+    return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
+  }
+
+  const l1ChainId = BigInt(await input.ctx.client.l1.getChainId());
+  const isL1Origin =
+    input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
+    input.ctx.resolvedToken.originChainId === 0n ||
+    input.ctx.resolvedToken.originChainId === l1ChainId;
+
+  if (isL1Origin) {
+    return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
+  }
+
+  const transferData = encodeNativeTokenVaultTransferData(
+    input.amount,
+    input.receiver,
+    input.token,
+  );
+
+  return encodeSecondBridgeDataV1(input.ctx.resolvedToken.assetId, transferData);
+}
 
 async function getPriorityGasModel(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
@@ -142,10 +175,16 @@ export function routeErc20NonBase(): DepositRouteStrategy {
       const secondBridgeCalldata = await wrapAs(
         'INTERNAL',
         OP_DEPOSITS.nonbase.encodeCalldata,
-        () => Promise.resolve(encodeSecondBridgeErc20Args(p.token, p.amount, receiver)),
+        () =>
+          encodeSecondBridgeErc20DepositCalldata({
+            ctx,
+            token: p.token,
+            amount: p.amount,
+            receiver,
+          }),
         {
           ctx: {
-            where: 'encodeSecondBridgeErc20Args',
+            where: 'encodeSecondBridgeErc20DepositCalldata',
             token: p.token,
             amount: p.amount.toString(),
           },


### PR DESCRIPTION
## Summary

Fixes ERC-20 non-base deposit calldata for tokens that are represented on L1 but originate from another ZK chain.

The route now keeps the legacy `(token, amount, receiver)` second-bridge encoding only for L1-origin tokens. When the resolved token origin chain differs from the L1 chain, it encodes the V1 Native Token Vault payload instead:

- `bytes1(0x01)` prefix
- `abi.encode(bytes32 assetId, bytes transferData)`
- `transferData = abi.encode(uint256 amount, address receiver, address token)`

I applied the same route fix to both ethers and viem adapters because both had the same ERC-20 non-base encoding path. The L1 contract error `LegacyEncodingUsedForNonL1Token` was already present in the error ABI registry, so this change focuses on avoiding that revert rather than adding duplicate ABI data.

Fixes #97.

## Validation

- `bun test src/adapters/__tests__/deposits/erc20-nonbase.test.ts`
- `bun test src/adapters/__tests__ src/core`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bunx prettier --check src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts src/adapters/__tests__/adapter-harness.ts src/adapters/__tests__/decode-helpers.ts src/adapters/__tests__/deposits/erc20-nonbase.test.ts`
- `bunx eslint --no-warn-ignored src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts src/adapters/__tests__/adapter-harness.ts src/adapters/__tests__/decode-helpers.ts src/adapters/__tests__/deposits/erc20-nonbase.test.ts`
- `git diff --check`

Note: `bun run lint` exits successfully with four pre-existing `no-console` warnings in unrelated files.
