### PR TITLE
fix: update server version for tests

### DIFF
--- a/.github/workflows/ci-scheduled-e2e.yaml
+++ b/.github/workflows/ci-scheduled-e2e.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Run ZKsync OS (L1-L2)
         uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
         with:
-          version: v0.19.0
+          version: v0.20.1
           protocol_version: v30.2
 
       - name: Compile test contracts

--- a/.github/workflows/ci-scheduled-e2e.yaml
+++ b/.github/workflows/ci-scheduled-e2e.yaml
@@ -36,7 +36,7 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
           version: v0.20.1
           protocol_version: v30.2

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -66,7 +66,7 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
           version: v0.20.1
           protocol_version: v30.2
@@ -195,7 +195,7 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
           version: v0.20.1
           protocol_version: v30.2
@@ -244,7 +244,7 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (multi-chain)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
           version: v0.20.1
           protocol_version: v31.0
@@ -308,7 +308,7 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (multi-chain)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
           version: v0.20.1
           protocol_version: v31.0

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run ZKsync OS (L1-L2)
         uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
         with:
-          version: v0.19.0
+          version: v0.20.1
           protocol_version: v30.2
  
       - name: Compile test contracts
@@ -197,7 +197,7 @@ jobs:
       - name: Run ZKsync OS (L1-L2)
         uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
         with:
-          version: v0.19.0
+          version: v0.20.1
           protocol_version: v30.2
 
       - name: Setup Bun
@@ -246,7 +246,7 @@ jobs:
       - name: Run ZKsync OS (multi-chain)
         uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
         with:
-          version: v0.19.0
+          version: v0.20.1
           protocol_version: v31.0
           setup: multi_chain
           l2_ports: |
@@ -310,7 +310,7 @@ jobs:
       - name: Run ZKsync OS (multi-chain)
         uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
         with:
-          version: v0.19.0
+          version: v0.20.1
           protocol_version: v31.0
           setup: multi_chain
           l2_ports: |


### PR DESCRIPTION
# What :computer:

Update ZKsync OS server version for tests.

# Why :hand:

Tests are failing on older server version.