### PR TITLE
chore: enable interop tests

### DIFF
--- a/.github/workflows/ci-scheduled-e2e.yaml
+++ b/.github/workflows/ci-scheduled-e2e.yaml
@@ -36,9 +36,9 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
-          version: v0.19.0
+          version: v0.20.2
           protocol_version: v30.2
 
       - name: Compile test contracts

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -224,7 +224,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -288,7 +288,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -281,7 +281,7 @@ jobs:
           DST_L2_RPC: http://localhost:3051
           PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
         run: |
-          bun test ${{ matrix.suite }} --timeout 300000
+          bun test ${{ matrix.suite }} --timeout 600000
 
   e2e-interop:
     name: e2e-interop (${{ matrix.adapter }})
@@ -345,4 +345,4 @@ jobs:
           DST_L2_RPC: http://localhost:3051
           PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
         run: |
-          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 300000
+          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 600000

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -66,9 +66,9 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
-          version: v0.19.0
+          version: v0.20.2
           protocol_version: v30.2
  
       - name: Compile test contracts
@@ -195,9 +195,9 @@ jobs:
           version: v1.5.1
 
       - name: Run ZKsync OS (L1-L2)
-        uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
-          version: v0.19.0
+          version: v0.20.2
           protocol_version: v30.2
 
       - name: Setup Bun
@@ -219,130 +219,130 @@ jobs:
         run: |
           bun test ${{ matrix.suite }} --path-ignore-patterns='**/interop*' --timeout 100000
 
-  # docs-interop-examples:
-  #   name: docs-interop-examples (${{ matrix.suite }})
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       suite:
-  #         - "docs/snippets/ethers/**/*interop*"
-  #         - "docs/snippets/viem/**/*interop*"
+  docs-interop-examples:
+    name: docs-interop-examples (${{ matrix.suite }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - "docs/snippets/ethers/**/*interop*"
+          - "docs/snippets/viem/**/*interop*"
 
-  #   steps:
-  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-  #     - name: Install build deps
-  #       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
 
-  #     - name: Install Foundry (anvil)
-  #       uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
-  #       with:
-  #         version: v1.5.1
+      - name: Install Foundry (anvil)
+        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
+        with:
+          version: v1.5.1
 
-  #     - name: Run ZKsync OS (multi-chain)
-  #       uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
-  #       with:
-  #         version: v0.19.0
-  #         protocol_version: v31.0
-  #         setup: multi_chain
-  #         l2_ports: |
-  #           506: 3052
-  #           6565: 3050
-  #           6566: 3051
+      - name: Run ZKsync OS (multi-chain)
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
+        with:
+          version: v0.20.2
+          protocol_version: v31.0
+          setup: multi_chain
+          l2_ports: |
+            506: 3052
+            6565: 3050
+            6566: 3051
 
-  #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
-  #       with:
-  #         bun-version: '1.3.11'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
+        with:
+          bun-version: '1.3.11'
 
-  #     - name: Install deps
-  #       run: bun install --frozen-lockfile
+      - name: Install deps
+        run: bun install --frozen-lockfile
 
-  #     - name: Set up interop environment
-  #       env:
-  #         L1_RPC: http://localhost:8545
-  #         GW_RPC: http://localhost:3052
-  #         SRC_L2_RPC: http://localhost:3050
-  #         DST_L2_RPC: http://localhost:3051
-  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-  #       run: |
-  #         set -eo pipefail
-  #         bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
+      - name: Set up interop environment
+        env:
+          L1_RPC: http://localhost:8545
+          GW_RPC: http://localhost:3052
+          SRC_L2_RPC: http://localhost:3050
+          DST_L2_RPC: http://localhost:3051
+          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+        run: |
+          set -eo pipefail
+          bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
 
-  #     - name: Run interop snippet tests
-  #       env:
-  #         L1_RPC: http://localhost:8545
-  #         GW_RPC: http://localhost:3052
-  #         SRC_L2_RPC: http://localhost:3050
-  #         DST_L2_RPC: http://localhost:3051
-  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-  #       run: |
-  #         bun test ${{ matrix.suite }} --timeout 300000
+      - name: Run interop snippet tests
+        env:
+          L1_RPC: http://localhost:8545
+          GW_RPC: http://localhost:3052
+          SRC_L2_RPC: http://localhost:3050
+          DST_L2_RPC: http://localhost:3051
+          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+        run: |
+          bun test ${{ matrix.suite }} --timeout 300000
 
-  # e2e-interop:
-  #   name: e2e-interop (${{ matrix.adapter }})
-  #   permissions:
-  #     contents: read
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       adapter:
-  #         - ethers
-  #         - viem
+  e2e-interop:
+    name: e2e-interop (${{ matrix.adapter }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - ethers
+          - viem
 
-  #   steps:
-  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-  #     - name: Install build deps
-  #       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
 
-  #     - name: Install Foundry (anvil)
-  #       uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
-  #       with:
-  #         version: v1.5.1
+      - name: Install Foundry (anvil)
+        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
+        with:
+          version: v1.5.1
 
-  #     - name: Run ZKsync OS (multi-chain)
-  #       uses: matter-labs/zksync-server-action@6632ab9a6bd841c7849e8d62a4984734e018d89f # v0.1.1
-  #       with:
-  #         version: v0.19.0
-  #         protocol_version: v31.0
-  #         setup: multi_chain
-  #         l2_ports: |
-  #           506: 3052
-  #           6565: 3050
-  #           6566: 3051
+      - name: Run ZKsync OS (multi-chain)
+        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
+        with:
+          version: v0.20.2
+          protocol_version: v31.0
+          setup: multi_chain
+          l2_ports: |
+            506: 3052
+            6565: 3050
+            6566: 3051
 
-  #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
-  #       with:
-  #         bun-version: '1.3.11'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
+        with:
+          bun-version: '1.3.11'
 
-  #     - name: Install deps
-  #       run: bun install --frozen-lockfile
+      - name: Install deps
+        run: bun install --frozen-lockfile
 
-  #     - name: Set up interop environment
-  #       env:
-  #         L1_RPC: http://localhost:8545
-  #         GW_RPC: http://localhost:3052
-  #         SRC_L2_RPC: http://localhost:3050
-  #         DST_L2_RPC: http://localhost:3051
-  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-  #       run: |
-  #         set -eo pipefail
-  #         bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
+      - name: Set up interop environment
+        env:
+          L1_RPC: http://localhost:8545
+          GW_RPC: http://localhost:3052
+          SRC_L2_RPC: http://localhost:3050
+          DST_L2_RPC: http://localhost:3051
+          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+        run: |
+          set -eo pipefail
+          bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
 
-  #     - name: Run interop e2e tests
-  #       env:
-  #         L1_RPC: http://localhost:8545
-  #         GW_RPC: http://localhost:3052
-  #         SRC_L2_RPC: http://localhost:3050
-  #         DST_L2_RPC: http://localhost:3051
-  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-  #       run: |
-  #         bun run test:e2e:interop:${{ matrix.adapter }} --timeout 300000
+      - name: Run interop e2e tests
+        env:
+          L1_RPC: http://localhost:8545
+          GW_RPC: http://localhost:3052
+          SRC_L2_RPC: http://localhost:3050
+          DST_L2_RPC: http://localhost:3051
+          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+        run: |
+          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 300000

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -217,7 +217,7 @@ jobs:
           L2_RPC: http://localhost:3050
           PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
         run: |
-          bun test ${{ matrix.suite }} --path-ignore-patterns='**/interop*' --timeout 100000
+          bun test ${{ matrix.suite }} --path-ignore-patterns='**/interop*' --timeout 200000
 
   docs-interop-examples:
     name: docs-interop-examples (${{ matrix.suite }})

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -281,7 +281,7 @@ jobs:
           DST_L2_RPC: http://localhost:3051
           PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
         run: |
-          bun test ${{ matrix.suite }} --timeout 600000
+          bun test ${{ matrix.suite }} --timeout 900000
 
   e2e-interop:
     name: e2e-interop (${{ matrix.adapter }})
@@ -345,4 +345,4 @@ jobs:
           DST_L2_RPC: http://localhost:3051
           PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
         run: |
-          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 600000
+          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 900000

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -224,7 +224,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -288,7 +288,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "test:watch": "bun test --watch",
     "test:cov": "bun test --coverage",
     "test:core": "bun test src/core",
-    "test:docs": "bun test docs/snippets --timeout 100000"
+    "test:docs": "bun test docs/snippets --timeout 200000"
   },
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
# What :computer:

Re-enable interop docs and e2e tests.

# Why :hand:

New server version with the proper config fixes has been released, so the tests can be now re-enabled.