### PR TITLE
fix: use V1 deposit encoding for non-L1-origin ERC-20 tokens

### DIFF
--- a/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
@@ -147,6 +147,36 @@ describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
     expect(decoded.token).toBe(ERC20_TOKEN.toLowerCase());
   });
 
+  it('uses V1 calldata for a non-L1 assetId even when originChainId reads as 0 (bridged L1 token, e.g. ZK)', async () => {
+    const harness = factory();
+    const ctx = makeDepositContext(harness, {
+      l2GasLimit: MIN_L2_GAS_FOR_ERC20,
+      baseTokenL1: FORMAL_ETH_ADDRESS,
+      baseIsEth: true,
+      resolvedToken: makeResolvedErc20Token({ originChainId: 0n }),
+    });
+    const amount = 1_000n;
+    const baseCost = 3_000n;
+
+    setBridgehubBaseToken(harness, ctx, FORMAL_ETH_ADDRESS);
+    setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });
+    setErc20Allowance(harness, ERC20_TOKEN, ctx.sender, ctx.l1AssetRouter, amount);
+
+    const res = await ROUTES[kind].build(
+      { token: ERC20_TOKEN, amount, to: RECEIVER } as any,
+      ctx as any,
+    );
+
+    const bridge = res.steps[0];
+    const secondBridgeCalldata =
+      kind === 'ethers'
+        ? decodeTwoBridgeOuter((bridge.tx as any).data).secondBridgeCalldata
+        : ((bridge.tx as any).args?.[0] as any).secondBridgeCalldata;
+    const decoded = decodeSecondBridgeDataV1(secondBridgeCalldata);
+
+    expect(decoded.assetId.toLowerCase()).toBe(NON_L1_ORIGIN_ASSET_ID.toLowerCase());
+  });
+
   it('requires approvals when deposit and base allowances are insufficient', async () => {
     const harness = factory();
     const ctx = makeDepositContext(harness, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });

--- a/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
@@ -1,7 +1,7 @@
 // src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
 
 import type { DepositRouteStrategy } from './types';
-import { AbiCoder, Contract, Interface } from 'ethers';
+import { AbiCoder, Contract, Interface, keccak256 } from 'ethers';
 import type { TransactionRequest } from 'ethers';
 import {
   encodeNativeTokenVaultTransferData,
@@ -17,7 +17,13 @@ import { buildFeeBreakdown } from '../../../../../core/resources/deposits/fee.ts
 
 import { quoteL2BaseCost } from '../services/fee.ts';
 import { quoteL1Gas, determineErc20L2Gas } from '../services/gas.ts';
-import { L2_ASSET_ROUTER_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../../../core/constants.ts';
+import {
+  L2_ASSET_ROUTER_ADDRESS,
+  L2_NATIVE_TOKEN_VAULT_ADDRESS,
+  SAFE_L1_BRIDGE_GAS,
+} from '../../../../../core/constants.ts';
+import { createNTVCodec } from '../../../../../core/codec/ntv.ts';
+import type { Hex } from '../../../../../core/types/primitives';
 import {
   applyPriorityL2GasLimitBuffer,
   derivePriorityBodyGasEstimateCap,
@@ -28,6 +34,10 @@ import { getPriorityTxGasBreakdown } from './priority';
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_L2_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const ntvCodec = createNTVCodec({
+  encode: (types, values) => AbiCoder.defaultAbiCoder().encode(types, values) as Hex,
+  keccak256: (data) => keccak256(data) as Hex,
+});
 
 type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
@@ -45,10 +55,15 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
   }
 
   const { chainId: l1ChainId } = await input.ctx.client.l1.getNetwork();
+  // Legacy encoding is valid only for L1-native tokens; see L1AssetRouter._handleLegacyData.
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
+    BigInt(l1ChainId),
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
   const isL1Origin =
     input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.ctx.resolvedToken.originChainId === 0n ||
-    input.ctx.resolvedToken.originChainId === BigInt(l1ChainId);
+    input.ctx.resolvedToken.assetId.toLowerCase() === expectedL1AssetId.toLowerCase();
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);

--- a/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
@@ -1,7 +1,7 @@
 // src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
 
 import type { Abi, TransactionRequest } from 'viem';
-import { encodeAbiParameters, encodeFunctionData, zeroAddress } from 'viem';
+import { encodeAbiParameters, encodeFunctionData, keccak256, zeroAddress } from 'viem';
 
 import type { DepositRouteStrategy, ViemPlanWriteRequest } from './types';
 import type { PlanStep, ApprovalNeed } from '../../../../../core/types/flows/base';
@@ -15,7 +15,12 @@ import {
 import { createErrorHandlers } from '../../../errors/error-ops';
 import { OP_DEPOSITS } from '../../../../../core/types';
 import { isETH, normalizeAddrEq } from '../../../../../core/utils/addr';
-import { L2_ASSET_ROUTER_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../../../core/constants.ts';
+import {
+  L2_ASSET_ROUTER_ADDRESS,
+  L2_NATIVE_TOKEN_VAULT_ADDRESS,
+  SAFE_L1_BRIDGE_GAS,
+} from '../../../../../core/constants.ts';
+import { createNTVCodec } from '../../../../../core/codec/ntv.ts';
 
 import { quoteL1Gas, determineErc20L2Gas } from '../services/gas.ts';
 import { quoteL2BaseCost } from '../services/fee.ts';
@@ -29,6 +34,14 @@ import { buildApprovalRequest } from './approval';
 
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
+const ntvCodec = createNTVCodec({
+  encode: (types, values) =>
+    encodeAbiParameters(
+      types.map((t, i) => ({ type: t, name: `arg${i}` })),
+      values,
+    ),
+  keccak256,
+});
 
 type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
@@ -46,10 +59,15 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
   }
 
   const l1ChainId = BigInt(await input.ctx.client.l1.getChainId());
+  // Legacy encoding is valid only for L1-native tokens; see L1AssetRouter._handleLegacyData.
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
+    l1ChainId,
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
   const isL1Origin =
     input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.ctx.resolvedToken.originChainId === 0n ||
-    input.ctx.resolvedToken.originChainId === l1ChainId;
+    input.ctx.resolvedToken.assetId.toLowerCase() === expectedL1AssetId.toLowerCase();
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);


### PR DESCRIPTION
## What
`erc20-nonbase` deposits chose legacy vs V1 second-bridge encoding from the destination **L2** NTV's `originChainId`. When a non-L1-origin token's asset is not yet registered on the destination L2 NTV, `originChainId` reads `0`, so the SDK emits the **legacy** encoding — which `L1AssetRouter._handleLegacyData` rejects with `LegacyEncodingUsedForNonL1Token` (`0xfade089a`) because the token's registered assetId ≠ the L1-native assetId.

## Fix
Decide the encoding the same way the contract does: legacy only when the resolved assetId is zero or equals `encodeNTVAssetId(l1ChainId, token)`; otherwise V1. Uses already-resolved L1-NTV data, so it no longer depends on L2-NTV registration. Applied to both the viem and ethers adapters; added a regression test.

## Proof (contract rules)
- `L1AssetRouter._handleLegacyData` revert: https://github.com/matter-labs/era-contracts/blob/5e7d0b405b49f42131565a291a82f22565f72e33/l1-contracts/contracts/bridge/asset-router/L1AssetRouter.sol#L381-L392
- `DataEncoding.encodeNTVAssetId`: https://github.com/matter-labs/era-contracts/blob/5e7d0b405b49f42131565a291a82f22565f72e33/l1-contracts/contracts/common/libraries/DataEncoding.sol#L125
