### PR TITLE
ci: wait for chain RPCs to be ready before interop setup

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -246,7 +246,7 @@ jobs:
       - name: Run ZKsync OS (multi-chain)
         uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
-          version: v0.20.2
+          version: v0.20.8
           protocol_version: v31.0
           setup: multi_chain
           l2_ports: |
@@ -310,7 +310,7 @@ jobs:
       - name: Run ZKsync OS (multi-chain)
         uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
         with:
-          version: v0.20.2
+          version: v0.20.8
           protocol_version: v31.0
           setup: multi_chain
           l2_ports: |

--- a/scripts/interop-setup.ts
+++ b/scripts/interop-setup.ts
@@ -45,9 +45,49 @@ function log(msg: string) {
   process.stderr.write(msg + '\n');
 }
 
+async function rpcReady(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] }),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { result?: unknown };
+    return typeof body.result === 'string';
+  } catch {
+    return false;
+  }
+}
+
+async function waitForRpc(
+  url: string,
+  label: string,
+  timeoutMs = 120_000,
+  intervalMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await rpcReady(url))) {
+    if (Date.now() > deadline) {
+      throw new Error(`RPC ${label} (${url}) not ready after ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  log(`RPC ready: ${label} (${url})`);
+}
+
 async function main() {
   const PRIVATE_KEY = process.env.PRIVATE_KEY;
   if (!PRIVATE_KEY) throw new Error('PRIVATE_KEY env var is required');
+
+  // Chains are launched moments before this script runs, and the dst L2 (last to start) can still
+  // be binding its RPC. Wait for every endpoint before use so we don't race into an ECONNREFUSED.
+  await Promise.all([
+    waitForRpc(L1_RPC, 'L1'),
+    waitForRpc(SRC_L2_RPC, 'L2 src'),
+    waitForRpc(DST_L2_RPC, 'L2 dst'),
+    waitForRpc(GW_RPC, 'GW'),
+  ]);
 
   const l1 = new JsonRpcProvider(L1_RPC);
   const l2Src = new JsonRpcProvider(SRC_L2_RPC);


### PR DESCRIPTION
## What
`e2e-interop` and `docs-interop-examples` intermittently fail with `ECONNREFUSED` in the "Set up interop environment" step.

The multi-chain setup launches the chains with only a short boot grace (`boot_grace_seconds: 3`). The destination L2 (the last chain to start) often hasn't bound its RPC yet, and `interop-setup.ts` immediately deposits to it, so the setup races straight into `ECONNREFUSED` (the src L2 deposit succeeds, the dst L2 deposit fails). It's timing-dependent, which is why it passes on some runs and fails on others.

## Fix
`interop-setup.ts` now waits for every RPC endpoint (L1, src L2, dst L2, GW) to respond to `eth_chainId` before running the setup, with a bounded timeout. This removes the dependency on boot timing and makes the interop jobs deterministic.
