### PR TITLE
fix: use V1 deposit encoding for non-L1-origin ERC-20 tokens

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -219,130 +219,132 @@ jobs:
         run: |
           bun test ${{ matrix.suite }} --path-ignore-patterns='**/interop*' --timeout 200000
 
-  docs-interop-examples:
-    name: docs-interop-examples (${{ matrix.suite }})
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-          - "docs/snippets/ethers/**/*interop*"
-          - "docs/snippets/viem/**/*interop*"
+  # Disabling interop tests for now as GW is no longer supported.
+  #
+  # docs-interop-examples:
+  #   name: docs-interop-examples (${{ matrix.suite }})
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       suite:
+  #         - "docs/snippets/ethers/**/*interop*"
+  #         - "docs/snippets/viem/**/*interop*"
 
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+  #   steps:
+  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Install build deps
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
+  #     - name: Install build deps
+  #       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
 
-      - name: Install Foundry (anvil)
-        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
-        with:
-          version: v1.5.1
+  #     - name: Install Foundry (anvil)
+  #       uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
+  #       with:
+  #         version: v1.5.1
 
-      - name: Run ZKsync OS (multi-chain)
-        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
-        with:
-          version: v0.20.2
-          protocol_version: v31.0
-          setup: multi_chain
-          l2_ports: |
-            506: 3052
-            6565: 3050
-            6566: 3051
+  #     - name: Run ZKsync OS (multi-chain)
+  #       uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
+  #       with:
+  #         version: v0.20.2
+  #         protocol_version: v31.0
+  #         setup: multi_chain
+  #         l2_ports: |
+  #           506: 3052
+  #           6565: 3050
+  #           6566: 3051
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
-        with:
-          bun-version: '1.3.11'
+  #     - name: Setup Bun
+  #       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
+  #       with:
+  #         bun-version: '1.3.11'
 
-      - name: Install deps
-        run: bun install --frozen-lockfile
+  #     - name: Install deps
+  #       run: bun install --frozen-lockfile
 
-      - name: Set up interop environment
-        env:
-          L1_RPC: http://localhost:8545
-          GW_RPC: http://localhost:3052
-          SRC_L2_RPC: http://localhost:3050
-          DST_L2_RPC: http://localhost:3051
-          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-        run: |
-          set -eo pipefail
-          bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
+  #     - name: Set up interop environment
+  #       env:
+  #         L1_RPC: http://localhost:8545
+  #         GW_RPC: http://localhost:3052
+  #         SRC_L2_RPC: http://localhost:3050
+  #         DST_L2_RPC: http://localhost:3051
+  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+  #       run: |
+  #         set -eo pipefail
+  #         bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
 
-      - name: Run interop snippet tests
-        env:
-          L1_RPC: http://localhost:8545
-          GW_RPC: http://localhost:3052
-          SRC_L2_RPC: http://localhost:3050
-          DST_L2_RPC: http://localhost:3051
-          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-        run: |
-          bun test ${{ matrix.suite }} --timeout 900000
+  #     - name: Run interop snippet tests
+  #       env:
+  #         L1_RPC: http://localhost:8545
+  #         GW_RPC: http://localhost:3052
+  #         SRC_L2_RPC: http://localhost:3050
+  #         DST_L2_RPC: http://localhost:3051
+  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+  #       run: |
+  #         bun test ${{ matrix.suite }} --timeout 900000
 
-  e2e-interop:
-    name: e2e-interop (${{ matrix.adapter }})
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        adapter:
-          - ethers
-          - viem
+  # e2e-interop:
+  #   name: e2e-interop (${{ matrix.adapter }})
+  #   permissions:
+  #     contents: read
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       adapter:
+  #         - ethers
+  #         - viem
 
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+  #   steps:
+  #     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Install build deps
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
+  #     - name: Install build deps
+  #       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lcov
 
-      - name: Install Foundry (anvil)
-        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
-        with:
-          version: v1.5.1
+  #     - name: Install Foundry (anvil)
+  #       uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
+  #       with:
+  #         version: v1.5.1
 
-      - name: Run ZKsync OS (multi-chain)
-        uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
-        with:
-          version: v0.20.2
-          protocol_version: v31.0
-          setup: multi_chain
-          l2_ports: |
-            506: 3052
-            6565: 3050
-            6566: 3051
+  #     - name: Run ZKsync OS (multi-chain)
+  #       uses: matter-labs/zksync-server-action@fa7f861c734c7a41d8c746e8fadc236da91ec15c # v0.1.3
+  #       with:
+  #         version: v0.20.2
+  #         protocol_version: v31.0
+  #         setup: multi_chain
+  #         l2_ports: |
+  #           506: 3052
+  #           6565: 3050
+  #           6566: 3051
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
-        with:
-          bun-version: '1.3.11'
+  #     - name: Setup Bun
+  #       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.0.2
+  #       with:
+  #         bun-version: '1.3.11'
 
-      - name: Install deps
-        run: bun install --frozen-lockfile
+  #     - name: Install deps
+  #       run: bun install --frozen-lockfile
 
-      - name: Set up interop environment
-        env:
-          L1_RPC: http://localhost:8545
-          GW_RPC: http://localhost:3052
-          SRC_L2_RPC: http://localhost:3050
-          DST_L2_RPC: http://localhost:3051
-          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-        run: |
-          set -eo pipefail
-          bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
+  #     - name: Set up interop environment
+  #       env:
+  #         L1_RPC: http://localhost:8545
+  #         GW_RPC: http://localhost:3052
+  #         SRC_L2_RPC: http://localhost:3050
+  #         DST_L2_RPC: http://localhost:3051
+  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+  #       run: |
+  #         set -eo pipefail
+  #         bun run scripts/interop-setup.ts >> "$GITHUB_ENV"
 
-      - name: Run interop e2e tests
-        env:
-          L1_RPC: http://localhost:8545
-          GW_RPC: http://localhost:3052
-          SRC_L2_RPC: http://localhost:3050
-          DST_L2_RPC: http://localhost:3051
-          PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
-        run: |
-          bun run test:e2e:interop:${{ matrix.adapter }} --timeout 900000
+  #     - name: Run interop e2e tests
+  #       env:
+  #         L1_RPC: http://localhost:8545
+  #         GW_RPC: http://localhost:3052
+  #         SRC_L2_RPC: http://localhost:3050
+  #         DST_L2_RPC: http://localhost:3051
+  #         PRIVATE_KEY: '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110'
+  #       run: |
+  #         bun run test:e2e:interop:${{ matrix.adapter }} --timeout 900000

--- a/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/deposits/erc20-nonbase.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import { AbiCoder, Interface } from 'ethers';
 import { routeErc20NonBase as routeEthers } from '../../ethers/resources/deposits/routes/erc20-nonbase.ts';
 import { routeErc20NonBase as routeViem } from '../../viem/resources/deposits/routes/erc20-nonbase.ts';
 import {
@@ -9,7 +10,14 @@ import {
   setErc20Allowance,
   describeForAdapters,
 } from '../adapter-harness.ts';
-import { FORMAL_ETH_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../core/constants.ts';
+import {
+  FORMAL_ETH_ADDRESS,
+  L2_ASSET_ROUTER_ADDRESS,
+  SAFE_L1_BRIDGE_GAS,
+} from '../../../core/constants.ts';
+import { IL1AssetRouterABI, L1NativeTokenVaultABI } from '../../../core/abi.ts';
+import { applyPriorityL2GasLimitBuffer } from '../../../core/resources/deposits/priority.ts';
+import { getPriorityTxGasBreakdown } from '../../viem/resources/deposits/routes/priority.ts';
 import { isZKsyncError } from '../../../core/types/errors.ts';
 import type { ResolvedToken } from '../../../core/types/flows/token.ts';
 import type { Address, Hex } from '../../../core/types/primitives.ts';
@@ -26,6 +34,8 @@ const ROUTES = {
   ethers: routeEthers(),
   viem: routeViem(),
 } as const;
+const IL1AssetRouter = new Interface(IL1AssetRouterABI as any);
+const L1NativeTokenVault = new Interface(L1NativeTokenVaultABI as any);
 
 const MIN_L2_GAS_FOR_ERC20 = 2_500_000n;
 
@@ -35,6 +45,8 @@ const BASE_TOKEN = ADAPTER_TEST_ADDRESSES.baseTokenFor324;
 const RECEIVER = '0x4444444444444444444444444444444444444444' as const;
 const BASE_TOKEN_ASSET_ID = `0x${'11'.repeat(32)}` as Hex;
 const NON_L1_ORIGIN_ASSET_ID = `0x${'22'.repeat(32)}` as Hex;
+const ERC20_METADATA = '0x123456' as Hex;
+const PRIORITY_L2_CALLDATA = '0x12345678' as Hex;
 
 function makeResolvedErc20Token(overrides: Partial<ResolvedToken> = {}): ResolvedToken {
   return {
@@ -55,6 +67,19 @@ const noReturnApproveError = () =>
   Object.assign(new Error('The contract function "approve" returned no data ("0x").'), {
     name: 'ContractFunctionExecutionError',
   });
+
+function encodeBridgeMintCalldata(input: {
+  sender: Address;
+  receiver: Address;
+  token: Address;
+  amount: bigint;
+  erc20Metadata: Hex;
+}): Hex {
+  return AbiCoder.defaultAbiCoder().encode(
+    ['address', 'address', 'address', 'uint256', 'bytes'],
+    [input.sender, input.receiver, input.token, input.amount, input.erc20Metadata],
+  ) as Hex;
+}
 
 describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
   it('handles non-base ERC-20 where fees are paid in ETH (no approvals required)', async () => {
@@ -145,6 +170,106 @@ describeForAdapters('adapters/deposits/routeErc20NonBase', (kind, factory) => {
     expect(decoded.amount).toBe(amount);
     expect(decoded.receiver).toBe(RECEIVER.toLowerCase());
     expect(decoded.token).toBe(ERC20_TOKEN.toLowerCase());
+  });
+
+  it('uses V1 second-bridge calldata when the destination origin chain is unresolved', async () => {
+    const harness = factory();
+    const ctx = makeDepositContext(harness, {
+      l2GasLimit: MIN_L2_GAS_FOR_ERC20,
+      baseTokenL1: FORMAL_ETH_ADDRESS,
+      baseIsEth: true,
+      resolvedToken: makeResolvedErc20Token({ originChainId: 0n }),
+    });
+    const amount = 1_000n;
+    const baseCost = 3_000n;
+
+    setBridgehubBaseToken(harness, ctx, FORMAL_ETH_ADDRESS);
+    setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: MIN_L2_GAS_FOR_ERC20 });
+    setErc20Allowance(harness, ERC20_TOKEN, ctx.sender, ctx.l1AssetRouter, amount);
+
+    const res = await ROUTES[kind].build(
+      { token: ERC20_TOKEN, amount, to: RECEIVER } as any,
+      ctx as any,
+    );
+
+    const bridge = res.steps[0];
+    const secondBridgeCalldata =
+      kind === 'ethers'
+        ? decodeTwoBridgeOuter((bridge.tx as any).data).secondBridgeCalldata
+        : ((bridge.tx as any).args?.[0] as any).secondBridgeCalldata;
+    const decoded = decodeSecondBridgeDataV1(secondBridgeCalldata);
+
+    expect(decoded.assetId.toLowerCase()).toBe(NON_L1_ORIGIN_ASSET_ID.toLowerCase());
+    expect(decoded.amount).toBe(amount);
+    expect(decoded.receiver).toBe(RECEIVER.toLowerCase());
+    expect(decoded.token).toBe(ERC20_TOKEN.toLowerCase());
+  });
+
+  it('uses asset-router priority gas modeling when destination origin chain is unresolved', async () => {
+    const harness = factory();
+    const ctx = makeDepositContext(harness, {
+      l2GasLimit: undefined,
+      baseTokenL1: FORMAL_ETH_ADDRESS,
+      baseIsEth: true,
+      resolvedToken: makeResolvedErc20Token({ originChainId: 0n }),
+    });
+    const amount = 1_000n;
+    const baseCost = 3_000n;
+    const bridgeMintCalldata = encodeBridgeMintCalldata({
+      sender: ctx.sender,
+      receiver: RECEIVER,
+      token: ERC20_TOKEN,
+      amount,
+      erc20Metadata: ERC20_METADATA,
+    });
+    const priorityBreakdown = getPriorityTxGasBreakdown({
+      sender: ctx.l1AssetRouter,
+      l2Contract: L2_ASSET_ROUTER_ADDRESS,
+      l2Value: 0n,
+      l2Calldata: PRIORITY_L2_CALLDATA,
+      gasPerPubdata: ctx.gasPerPubdata,
+    });
+    const expectedL2GasLimit = applyPriorityL2GasLimitBuffer({
+      chainIdL2: ctx.chainIdL2,
+      gasLimit: priorityBreakdown.derivedL2GasLimit,
+    });
+
+    harness.registry.set(
+      ADAPTER_TEST_ADDRESSES.l1NativeTokenVault,
+      L1NativeTokenVault,
+      'originChainId',
+      9n,
+      [NON_L1_ORIGIN_ASSET_ID],
+    );
+    harness.registry.set(
+      ADAPTER_TEST_ADDRESSES.l1NativeTokenVault,
+      L1NativeTokenVault,
+      'getERC20Getters',
+      ERC20_METADATA,
+      [ERC20_TOKEN, 9n],
+    );
+    harness.registry.set(
+      ADAPTER_TEST_ADDRESSES.l1AssetRouter,
+      IL1AssetRouter,
+      'getDepositCalldata',
+      PRIORITY_L2_CALLDATA,
+      [ctx.sender, NON_L1_ORIGIN_ASSET_ID, bridgeMintCalldata],
+    );
+    setBridgehubBaseToken(harness, ctx, FORMAL_ETH_ADDRESS);
+    setBridgehubBaseCost(harness, ctx, baseCost, { l2GasLimit: expectedL2GasLimit });
+    setErc20Allowance(harness, ERC20_TOKEN, ctx.sender, ctx.l1AssetRouter, amount);
+
+    const res = await ROUTES[kind].build(
+      { token: ERC20_TOKEN, amount, to: RECEIVER } as any,
+      ctx as any,
+    );
+    const bridge = res.steps[0];
+    const l2GasLimit =
+      kind === 'ethers'
+        ? decodeTwoBridgeOuter((bridge.tx as any).data).l2GasLimit
+        : ((bridge.tx as any).args?.[0] as any).l2GasLimit;
+
+    expect(BigInt(l2GasLimit)).toBe(expectedL2GasLimit);
   });
 
   it('requires approvals when deposit and base allowances are insufficient', async () => {

--- a/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
@@ -1,7 +1,7 @@
 // src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
 
 import type { DepositRouteStrategy } from './types';
-import { AbiCoder, Contract, Interface } from 'ethers';
+import { AbiCoder, Contract, Interface, keccak256 } from 'ethers';
 import type { TransactionRequest } from 'ethers';
 import {
   encodeNativeTokenVaultTransferData,
@@ -17,7 +17,13 @@ import { buildFeeBreakdown } from '../../../../../core/resources/deposits/fee.ts
 
 import { quoteL2BaseCost } from '../services/fee.ts';
 import { quoteL1Gas, determineErc20L2Gas } from '../services/gas.ts';
-import { L2_ASSET_ROUTER_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../../../core/constants.ts';
+import {
+  L2_ASSET_ROUTER_ADDRESS,
+  L2_NATIVE_TOKEN_VAULT_ADDRESS,
+  SAFE_L1_BRIDGE_GAS,
+} from '../../../../../core/constants.ts';
+import { createNTVCodec } from '../../../../../core/codec/ntv.ts';
+import type { Hex } from '../../../../../core/types/primitives';
 import {
   applyPriorityL2GasLimitBuffer,
   derivePriorityBodyGasEstimateCap,
@@ -28,11 +34,46 @@ import { getPriorityTxGasBreakdown } from './priority';
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_L2_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const ntvCodec = createNTVCodec({
+  encode: (types, values) => AbiCoder.defaultAbiCoder().encode(types, values) as Hex,
+  keccak256: (data) => keccak256(data) as Hex,
+});
 
 type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
   undeployedGasLimit?: bigint;
 };
+
+function isLegacySecondBridgeErc20Calldata(input: {
+  assetId: `0x${string}`;
+  l1ChainId: bigint;
+  token: `0x${string}`;
+}): boolean {
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
+    input.l1ChainId,
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
+
+  return (
+    input.assetId.toLowerCase() === ZERO_ASSET_ID ||
+    input.assetId.toLowerCase() === expectedL1AssetId.toLowerCase()
+  );
+}
+
+async function resolveErc20MetadataOriginChainId(input: {
+  l1NativeTokenVault: Awaited<
+    ReturnType<Parameters<DepositRouteStrategy['build']>[1]['contracts']['l1NativeTokenVault']>
+  >;
+  assetId: `0x${string}`;
+  resolvedOriginChainId: bigint;
+}): Promise<bigint> {
+  if (input.resolvedOriginChainId !== 0n) {
+    return input.resolvedOriginChainId;
+  }
+
+  return (await input.l1NativeTokenVault.originChainId(input.assetId)) as bigint;
+}
 
 async function encodeSecondBridgeErc20DepositCalldata(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
@@ -44,11 +85,12 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
   }
 
-  const { chainId: l1ChainId } = await input.ctx.client.l1.getNetwork();
-  const isL1Origin =
-    input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.ctx.resolvedToken.originChainId === 0n ||
-    input.ctx.resolvedToken.originChainId === BigInt(l1ChainId);
+  const { chainId } = await input.ctx.client.l1.getNetwork();
+  const isL1Origin = isLegacySecondBridgeErc20Calldata({
+    assetId: input.ctx.resolvedToken.assetId,
+    l1ChainId: BigInt(chainId),
+    token: input.token,
+  });
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
@@ -73,12 +115,14 @@ async function getPriorityGasModel(input: {
     const l1NativeTokenVault = await input.ctx.contracts.l1NativeTokenVault();
     const l1AssetRouter = await input.ctx.contracts.l1AssetRouter();
     const { chainId: l1ChainId } = await input.ctx.client.l1.getNetwork();
-    const isFirstBridge =
-      input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-      input.ctx.resolvedToken.originChainId === 0n;
+    const isFirstBridge = input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID;
     const erc20MetadataOriginChainId = isFirstBridge
       ? BigInt(l1ChainId)
-      : input.ctx.resolvedToken.originChainId;
+      : await resolveErc20MetadataOriginChainId({
+          l1NativeTokenVault,
+          assetId: input.ctx.resolvedToken.assetId,
+          resolvedOriginChainId: input.ctx.resolvedToken.originChainId,
+        });
     const erc20Metadata = (await l1NativeTokenVault.getERC20Getters(
       input.token,
       erc20MetadataOriginChainId,

--- a/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/ethers/resources/deposits/routes/erc20-nonbase.ts
@@ -44,37 +44,6 @@ type PriorityGasModel = {
   undeployedGasLimit?: bigint;
 };
 
-function isLegacySecondBridgeErc20Calldata(input: {
-  assetId: `0x${string}`;
-  l1ChainId: bigint;
-  token: `0x${string}`;
-}): boolean {
-  const expectedL1AssetId = ntvCodec.encodeAssetId(
-    input.l1ChainId,
-    L2_NATIVE_TOKEN_VAULT_ADDRESS,
-    input.token,
-  );
-
-  return (
-    input.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.assetId.toLowerCase() === expectedL1AssetId.toLowerCase()
-  );
-}
-
-async function resolveErc20MetadataOriginChainId(input: {
-  l1NativeTokenVault: Awaited<
-    ReturnType<Parameters<DepositRouteStrategy['build']>[1]['contracts']['l1NativeTokenVault']>
-  >;
-  assetId: `0x${string}`;
-  resolvedOriginChainId: bigint;
-}): Promise<bigint> {
-  if (input.resolvedOriginChainId !== 0n) {
-    return input.resolvedOriginChainId;
-  }
-
-  return (await input.l1NativeTokenVault.originChainId(input.assetId)) as bigint;
-}
-
 async function encodeSecondBridgeErc20DepositCalldata(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
   token: `0x${string}`;
@@ -86,11 +55,13 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
   }
 
   const { chainId } = await input.ctx.client.l1.getNetwork();
-  const isL1Origin = isLegacySecondBridgeErc20Calldata({
-    assetId: input.ctx.resolvedToken.assetId,
-    l1ChainId: BigInt(chainId),
-    token: input.token,
-  });
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
+    BigInt(chainId),
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
+  const assetId = input.ctx.resolvedToken.assetId.toLowerCase();
+  const isL1Origin = assetId === ZERO_ASSET_ID || assetId === expectedL1AssetId.toLowerCase();
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
@@ -118,11 +89,9 @@ async function getPriorityGasModel(input: {
     const isFirstBridge = input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID;
     const erc20MetadataOriginChainId = isFirstBridge
       ? BigInt(l1ChainId)
-      : await resolveErc20MetadataOriginChainId({
-          l1NativeTokenVault,
-          assetId: input.ctx.resolvedToken.assetId,
-          resolvedOriginChainId: input.ctx.resolvedToken.originChainId,
-        });
+      : input.ctx.resolvedToken.originChainId !== 0n
+        ? input.ctx.resolvedToken.originChainId
+        : ((await l1NativeTokenVault.originChainId(input.ctx.resolvedToken.assetId)) as bigint);
     const erc20Metadata = (await l1NativeTokenVault.getERC20Getters(
       input.token,
       erc20MetadataOriginChainId,

--- a/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
@@ -48,37 +48,6 @@ type PriorityGasModel = {
   undeployedGasLimit?: bigint;
 };
 
-function isLegacySecondBridgeErc20Calldata(input: {
-  assetId: `0x${string}`;
-  l1ChainId: bigint;
-  token: `0x${string}`;
-}): boolean {
-  const expectedL1AssetId = ntvCodec.encodeAssetId(
-    input.l1ChainId,
-    L2_NATIVE_TOKEN_VAULT_ADDRESS,
-    input.token,
-  );
-
-  return (
-    input.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.assetId.toLowerCase() === expectedL1AssetId.toLowerCase()
-  );
-}
-
-async function resolveErc20MetadataOriginChainId(input: {
-  l1NativeTokenVault: Awaited<
-    ReturnType<Parameters<DepositRouteStrategy['build']>[1]['contracts']['l1NativeTokenVault']>
-  >;
-  assetId: `0x${string}`;
-  resolvedOriginChainId: bigint;
-}): Promise<bigint> {
-  if (input.resolvedOriginChainId !== 0n) {
-    return input.resolvedOriginChainId;
-  }
-
-  return await input.l1NativeTokenVault.read.originChainId([input.assetId]);
-}
-
 async function encodeSecondBridgeErc20DepositCalldata(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
   token: `0x${string}`;
@@ -90,11 +59,13 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
   }
 
   const l1ChainId = BigInt(await input.ctx.client.l1.getChainId());
-  const isL1Origin = isLegacySecondBridgeErc20Calldata({
-    assetId: input.ctx.resolvedToken.assetId,
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
     l1ChainId,
-    token: input.token,
-  });
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
+  const assetId = input.ctx.resolvedToken.assetId.toLowerCase();
+  const isL1Origin = assetId === ZERO_ASSET_ID || assetId === expectedL1AssetId.toLowerCase();
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
@@ -122,11 +93,9 @@ async function getPriorityGasModel(input: {
     const isFirstBridge = input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID;
     const erc20MetadataOriginChainId = isFirstBridge
       ? l1ChainId
-      : await resolveErc20MetadataOriginChainId({
-          l1NativeTokenVault,
-          assetId: input.ctx.resolvedToken.assetId,
-          resolvedOriginChainId: input.ctx.resolvedToken.originChainId,
-        });
+      : input.ctx.resolvedToken.originChainId !== 0n
+        ? input.ctx.resolvedToken.originChainId
+        : await l1NativeTokenVault.read.originChainId([input.ctx.resolvedToken.assetId]);
     const erc20Metadata = await l1NativeTokenVault.read.getERC20Getters([
       input.token,
       erc20MetadataOriginChainId,

--- a/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
+++ b/src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
@@ -1,7 +1,7 @@
 // src/adapters/viem/resources/deposits/routes/erc20-nonbase.ts
 
 import type { Abi, TransactionRequest } from 'viem';
-import { encodeAbiParameters, encodeFunctionData, zeroAddress } from 'viem';
+import { encodeAbiParameters, encodeFunctionData, keccak256, zeroAddress } from 'viem';
 
 import type { DepositRouteStrategy, ViemPlanWriteRequest } from './types';
 import type { PlanStep, ApprovalNeed } from '../../../../../core/types/flows/base';
@@ -15,7 +15,12 @@ import {
 import { createErrorHandlers } from '../../../errors/error-ops';
 import { OP_DEPOSITS } from '../../../../../core/types';
 import { isETH, normalizeAddrEq } from '../../../../../core/utils/addr';
-import { L2_ASSET_ROUTER_ADDRESS, SAFE_L1_BRIDGE_GAS } from '../../../../../core/constants.ts';
+import {
+  L2_ASSET_ROUTER_ADDRESS,
+  L2_NATIVE_TOKEN_VAULT_ADDRESS,
+  SAFE_L1_BRIDGE_GAS,
+} from '../../../../../core/constants.ts';
+import { createNTVCodec } from '../../../../../core/codec/ntv.ts';
 
 import { quoteL1Gas, determineErc20L2Gas } from '../services/gas.ts';
 import { quoteL2BaseCost } from '../services/fee.ts';
@@ -29,11 +34,50 @@ import { buildApprovalRequest } from './approval';
 
 const { wrapAs } = createErrorHandlers('deposits');
 const ZERO_ASSET_ID = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
+const ntvCodec = createNTVCodec({
+  encode: (types, values) =>
+    encodeAbiParameters(
+      types.map((t, i) => ({ type: t, name: `arg${i}` })),
+      values,
+    ),
+  keccak256,
+});
 
 type PriorityGasModel = {
   priorityFloorGasLimit?: bigint;
   undeployedGasLimit?: bigint;
 };
+
+function isLegacySecondBridgeErc20Calldata(input: {
+  assetId: `0x${string}`;
+  l1ChainId: bigint;
+  token: `0x${string}`;
+}): boolean {
+  const expectedL1AssetId = ntvCodec.encodeAssetId(
+    input.l1ChainId,
+    L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    input.token,
+  );
+
+  return (
+    input.assetId.toLowerCase() === ZERO_ASSET_ID ||
+    input.assetId.toLowerCase() === expectedL1AssetId.toLowerCase()
+  );
+}
+
+async function resolveErc20MetadataOriginChainId(input: {
+  l1NativeTokenVault: Awaited<
+    ReturnType<Parameters<DepositRouteStrategy['build']>[1]['contracts']['l1NativeTokenVault']>
+  >;
+  assetId: `0x${string}`;
+  resolvedOriginChainId: bigint;
+}): Promise<bigint> {
+  if (input.resolvedOriginChainId !== 0n) {
+    return input.resolvedOriginChainId;
+  }
+
+  return await input.l1NativeTokenVault.read.originChainId([input.assetId]);
+}
 
 async function encodeSecondBridgeErc20DepositCalldata(input: {
   ctx: Parameters<DepositRouteStrategy['build']>[1];
@@ -46,10 +90,11 @@ async function encodeSecondBridgeErc20DepositCalldata(input: {
   }
 
   const l1ChainId = BigInt(await input.ctx.client.l1.getChainId());
-  const isL1Origin =
-    input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-    input.ctx.resolvedToken.originChainId === 0n ||
-    input.ctx.resolvedToken.originChainId === l1ChainId;
+  const isL1Origin = isLegacySecondBridgeErc20Calldata({
+    assetId: input.ctx.resolvedToken.assetId,
+    l1ChainId,
+    token: input.token,
+  });
 
   if (isL1Origin) {
     return encodeSecondBridgeErc20Args(input.token, input.amount, input.receiver);
@@ -74,12 +119,14 @@ async function getPriorityGasModel(input: {
     const l1NativeTokenVault = await input.ctx.contracts.l1NativeTokenVault();
     const l1AssetRouter = await input.ctx.contracts.l1AssetRouter();
     const l1ChainId = BigInt(await input.ctx.client.l1.getChainId());
-    const isFirstBridge =
-      input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID ||
-      input.ctx.resolvedToken.originChainId === 0n;
+    const isFirstBridge = input.ctx.resolvedToken.assetId.toLowerCase() === ZERO_ASSET_ID;
     const erc20MetadataOriginChainId = isFirstBridge
       ? l1ChainId
-      : input.ctx.resolvedToken.originChainId;
+      : await resolveErc20MetadataOriginChainId({
+          l1NativeTokenVault,
+          assetId: input.ctx.resolvedToken.assetId,
+          resolvedOriginChainId: input.ctx.resolvedToken.originChainId,
+        });
     const erc20Metadata = await l1NativeTokenVault.read.getERC20Getters([
       input.token,
       erc20MetadataOriginChainId,


### PR DESCRIPTION
# What :computer:

- Replica of https://github.com/matter-labs/zksync-js/pull/108 but with singed commits and disabled interop testing

## What
`erc20-nonbase` deposits chose legacy vs V1 second-bridge encoding from the destination **L2** NTV's `originChainId`. When a non-L1-origin token's asset is not yet registered on the destination L2 NTV, `originChainId` reads `0`, so the SDK emits the **legacy** encoding — which `L1AssetRouter._handleLegacyData` rejects with `LegacyEncodingUsedForNonL1Token` (`0xfade089a`) because the token's registered assetId ≠ the L1-native assetId.

## Fix
Decide the encoding the same way the contract does: legacy only when the resolved assetId is zero or equals `encodeNTVAssetId(l1ChainId, token)`; otherwise V1. Uses already-resolved L1-NTV data, so it no longer depends on L2-NTV registration. Applied to both the viem and ethers adapters; added a regression test.

## Proof (contract rules)
- `L1AssetRouter._handleLegacyData` revert: https://github.com/matter-labs/era-contracts/blob/5e7d0b405b49f42131565a291a82f22565f72e33/l1-contracts/contracts/bridge/asset-router/L1AssetRouter.sol#L381-L392
- `DataEncoding.encodeNTVAssetId`: https://github.com/matter-labs/era-contracts/blob/5e7d0b405b49f42131565a291a82f22565f72e33/l1-contracts/contracts/common/libraries/DataEncoding.sol#L125


# Evidence :camera:

Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

# API Change Checklist :shield:

Check one:

- [ ] No API change
- [ ] API change (details below)

If API change, include:

- Touched API surface files from this API Gate list:
  - `package.json` (`exports` or `typesVersions`)
  - `src/index.ts`
  - `src/core/index.ts`
  - `src/adapters/ethers/index.ts`
  - `src/adapters/viem/index.ts`
  - `src/core/types/**`
  - any newly exported type from those entrypoints
- Compatibility impact (non-breaking or breaking)
- Docs/changelog context updated

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
