### PR TITLE
fix: read ethers ERC-20 allowance/asset-id via L2 provider

### DIFF
--- a/src/adapters/__tests__/interop/indirect.test.ts
+++ b/src/adapters/__tests__/interop/indirect.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'bun:test';
-import { Interface } from 'ethers';
+import { BrowserProvider, Interface } from 'ethers';
 
 import { routeIndirect as routeEthers } from '../../ethers/resources/interop/routes/indirect.ts';
 import { routeIndirect as routeViem } from '../../viem/resources/interop/routes/indirect.ts';
+import { resolveErc20AssetIds } from '../../ethers/resources/interop/services/erc20.ts';
+import { createEthersClient } from '../../ethers/client.ts';
+import { createContractsResource as createEthersContractsResource } from '../../ethers/resources/contracts/index.ts';
 import {
+  ADAPTER_TEST_ADDRESSES,
+  createEthersHarness,
   describeForAdapters,
   makeInteropContext,
   setErc20Allowance,
@@ -390,5 +395,45 @@ describeForAdapters('adapters/interop/routeIndirect', (kind, factory) => {
     const erc20Iface = new Interface(IERC20ABI);
     const approveArgs = erc20Iface.decodeFunctionData('approve', approveStep!.tx.data as Hex);
     expect(approveArgs[1]).toBe(amount);
+  });
+});
+
+// Needs a real BrowserProvider: the harness's plain signer reconnects to l2 and would mask the bug.
+describe('interop/resolveErc20AssetIds browser-wallet signer (ethers)', () => {
+  it('resolves asset ids via the read provider, not the wallet signer', async () => {
+    const harness = createEthersHarness();
+
+    let walletEthCalls = 0;
+    const walletRpc = {
+      request: async ({ method }: { method: string }) => {
+        switch (method) {
+          case 'eth_chainId':
+            return '0x144';
+          case 'eth_accounts':
+          case 'eth_requestAccounts':
+            return [ADAPTER_TEST_ADDRESSES.signer];
+          case 'eth_call':
+            walletEthCalls += 1;
+            throw new Error('Method eth_call is forbidden');
+          default:
+            throw new Error(`unexpected wallet method ${method}`);
+        }
+      },
+    };
+    const browserProvider = new BrowserProvider(walletRpc as any);
+    const signer = await browserProvider.getSigner();
+    const client = createEthersClient({ l1: harness.l1 as any, l2: harness.l2 as any, signer });
+
+    const token = '0x6666666666666666666666666666666666666666' as Address;
+    const ctx = makeTestBuildCtx('ethers', harness, {
+      client,
+      contracts: createEthersContractsResource(client) as any,
+    });
+    setL2TokenRegistration(harness, ctx.l2NativeTokenVault, token, TEST_ASSET_ID);
+
+    const assetIds = await resolveErc20AssetIds([token], ctx);
+
+    expect(assetIds.get(token.toLowerCase())).toBe(TEST_ASSET_ID);
+    expect(walletEthCalls).toBe(0);
   });
 });

--- a/src/adapters/__tests__/withdrawals/erc20-nonbase.test.ts
+++ b/src/adapters/__tests__/withdrawals/erc20-nonbase.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'bun:test';
+import { BrowserProvider } from 'ethers';
 
 import { routeErc20NonBase as routeEthers } from '../../ethers/resources/withdrawals/routes/erc20-nonbase.ts';
 import { routeErc20NonBase as routeViem } from '../../viem/resources/withdrawals/routes/erc20-nonbase.ts';
+import { createEthersClient } from '../../ethers/client.ts';
+import { createContractsResource as createEthersContractsResource } from '../../ethers/resources/contracts/index.ts';
 import {
   ADAPTER_TEST_ADDRESSES,
+  createEthersHarness,
   makeWithdrawalContext,
   setErc20Allowance,
   setL2TokenRegistration,
@@ -213,5 +217,53 @@ describeForAdapters('adapters/withdrawals/routeErc20NonBase', (kind, factory) =>
     }
     expect(isZKsyncError(caught)).toBe(true);
     expect(String(caught)).toMatch(/Failed to read L2 ERC-20 allowance/);
+  });
+});
+
+// Needs a real BrowserProvider: the harness's plain signer reconnects to l2 and would mask the bug.
+describe('adapters/withdrawals/routeErc20NonBase browser-wallet signer (ethers)', () => {
+  it('reads L2 allowance via the read provider, not the wallet signer', async () => {
+    const harness = createEthersHarness();
+
+    let walletEthCalls = 0;
+    const walletRpc = {
+      request: async ({ method }: { method: string }) => {
+        switch (method) {
+          case 'eth_chainId':
+            return '0x144';
+          case 'eth_accounts':
+          case 'eth_requestAccounts':
+            return [ADAPTER_TEST_ADDRESSES.signer];
+          case 'eth_call':
+            walletEthCalls += 1;
+            throw new Error('Method eth_call is forbidden');
+          default:
+            throw new Error(`unexpected wallet method ${method}`);
+        }
+      },
+    };
+    const browserProvider = new BrowserProvider(walletRpc as any);
+    const signer = await browserProvider.getSigner();
+
+    const client = createEthersClient({ l1: harness.l1 as any, l2: harness.l2 as any, signer });
+
+    const ctx = makeWithdrawalContext(harness, {
+      l2NativeTokenVault: L2_NATIVE_TOKEN_VAULT_ADDRESS,
+      l2AssetRouter: L2_ASSET_ROUTER_ADDRESS,
+    });
+    ctx.client = client;
+    ctx.contracts = createEthersContractsResource(client);
+
+    const amount = 5_000n;
+    setErc20Allowance(harness, TOKEN, ctx.sender, ctx.l2NativeTokenVault, amount);
+    setL2TokenRegistration(harness, ctx.l2NativeTokenVault, TOKEN, ASSET_ID);
+
+    const res = await routeEthers().build(
+      { token: TOKEN, amount, to: RECEIVER } as any,
+      ctx as any,
+    );
+
+    expect(res.steps.at(-1)?.key).toBe('l2-asset-router:withdraw');
+    expect(walletEthCalls).toBe(0);
   });
 });

--- a/src/adapters/ethers/resources/interop/services/erc20.ts
+++ b/src/adapters/ethers/resources/interop/services/erc20.ts
@@ -88,7 +88,8 @@ export async function resolveErc20AssetIds(
   const assetIds = new Map<string, Hex>();
   if (erc20Tokens.length === 0) return assetIds;
 
-  const ntv = new Contract(ctx.l2NativeTokenVault, L2NativeTokenVaultABI, ctx.client.getL2Signer());
+  // Read via l2, not the signer: a browser-wallet signer routes this eth_call to its own RPC, which may forbid it.
+  const ntv = new Contract(ctx.l2NativeTokenVault, L2NativeTokenVaultABI, ctx.client.l2);
 
   for (const token of erc20Tokens) {
     const assetId = (await ntv.getFunction('ensureTokenIsRegistered').staticCall(token)) as Hex;

--- a/src/adapters/ethers/resources/withdrawals/routes/erc20-nonbase.ts
+++ b/src/adapters/ethers/resources/withdrawals/routes/erc20-nonbase.ts
@@ -27,8 +27,8 @@ export function routeErc20NonBase(): WithdrawRouteStrategy {
       const steps: Array<PlanStep<TransactionRequest>> = [];
       const approvals: ApprovalNeed[] = [];
 
-      // L2 allowance
-      const erc20 = new Contract(p.token, IERC20ABI, ctx.client.getL2Signer());
+      // Read via l2, not the signer: a browser-wallet signer routes this eth_call to its own RPC, which may forbid it.
+      const erc20 = new Contract(p.token, IERC20ABI, ctx.client.l2);
       const current: bigint = (await wrapAs(
         'CONTRACT',
         OP_WITHDRAWALS.erc20.allowance,


### PR DESCRIPTION
## What

In the **ethers** adapter, read two L2 values through the read provider (`client.l2`) instead of `client.getL2Signer()`:

- `withdrawals/routes/erc20-nonbase.ts` — the L2 ERC-20 `allowance` read.
- `interop/services/erc20.ts` — the `ensureTokenIsRegistered` static call used for asset-id resolution.

## Why

Both are read-only `eth_call`s, but they were dispatched through the signer. With a browser-wallet signer (`BrowserProvider` / MetaMask), `resolveSignerFor` intentionally does **not** reconnect the signer to `l2` (ethers v6 cannot reconnect a `JsonRpcSigner`), so the call goes out over the wallet's own RPC connection. When the wallet is connected to a permissioned / wallet-scoped RPC that does not serve `eth_call`, the read fails (e.g. `Failed to read L2 ERC-20 allowance`) — even though the base-token (ETH) withdrawal path works, because it has no signer-backed read.

The **viem** adapter already reads these via the read client (`client.l2.readContract` / `simulateContract`), so this brings ethers in line. Every other ethers read (token resolution, gas estimation) already uses `client.l2`; these two were the only signer-backed reads.

## Evidence

- New regression tests construct a `BrowserProvider` signer whose `eth_call` is unavailable and assert the reads go through `l2` (red before the fix, green after). Note: the shared test harness's plain-object signer reconnects to `l2` and masks the bug, so the tests use a real `BrowserProvider` to reproduce it.
- `bun test` — full suite green (+2 tests, no new failures; the pre-existing `docs/snippets` failures require a live environment). `bun run typecheck` clean. `bun run lint` — no new warnings.
